### PR TITLE
feat: add possibility to add a default config path

### DIFF
--- a/zalfmas_common/service.py
+++ b/zalfmas_common/service.py
@@ -242,13 +242,16 @@ def handle_default_service_args(parser, config: dict=None):
     return config, args
 
 
-def create_default_args_parser(component_description):
+def create_default_args_parser(
+    component_description: str, default_config_path: str | None = None
+):
     parser = argparse.ArgumentParser(description=component_description)
     parser.add_argument(
         "config_toml",
         type=str,
         nargs="?",
         help="TOML configuration file",
+        default=default_config_path,
     )
     parser.add_argument(
         "--output_toml_config",


### PR DESCRIPTION
This pull request introduces an improvement to the argument parser in `zalfmas_common/service.py` by allowing a default configuration file path to be specified. This makes it easier to provide a fallback configuration file when running the service.

Should be non-breaking because when the default is set to None, the argument becomes required again and should notify the user. This is regarding the other runnable components that use this function. 

Enhancement to argument parsing:

* Updated the `create_default_args_parser` function to accept an optional `default_config_path` parameter, which sets a default value for the `config_toml` argument.